### PR TITLE
Add dynamic token price updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,5 +197,86 @@
 
     showLines();
   </script>
+  <script>
+    (() => {
+      const API_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6IjkyMzBkNGU3LWUyNjEtNGNiYi1hYzgzLTY4MDZmNDg5YzRhOSIsIm9yZ0lkIjoiNDUzNzM2IiwidXNlcklkIjoiNDY2ODMzIiwidHlwZUlkIjoiODVkOTcxZDMtODgzOS00NmYxLWJiMGEtM2IyY2Y5ZmE4NTU2IiwidHlwZSI6IlBST0pFQ1QiLCJpYXQiOjE3NDk4MDU3MTcsImV4cCI6NDkwNTU2NTcxN30.nbLVfn0ocROspwVeWXIOtw-d6Gm42Bnshujhlp3JrMI';
+      const TOKENS = {
+        '$WIF': 'EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm',
+        '$BONK': 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263',
+        '$FART': '9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump',
+        '$POPCAT': '7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr',
+        '$USELESS': 'Dz9mQ9NzkBcCsuGPFJ3r1bS4wgqKMHBPiVuniW8Mbonk'
+      };
+      const IF_TOKEN_ADDRESS = '';
+
+      const container = document.getElementById('lines-container');
+      const finalPriceEl = document.querySelector('.final-price');
+
+      function formatUsd(value) {
+        const n = Number(value);
+        if (n >= 1e9) return '$' + (n / 1e9).toFixed(1) + 'B';
+        if (n >= 1e6) return '$' + (n / 1e6).toFixed(1) + 'M';
+        if (n >= 1e3) return '$' + (n / 1e3).toFixed(1) + 'K';
+        return '$' + n.toFixed(2);
+      }
+
+      async function getTokenData(address) {
+        const headers = {
+          'X-API-Key': API_KEY,
+          'Content-Type': 'application/json'
+        };
+        const [priceRes, metaRes] = await Promise.all([
+          fetch('https://solana-gateway.moralis.io/token/mainnet/prices', {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ tokens: [{ tokenAddress: address }] })
+          }),
+          fetch(`https://solana-gateway.moralis.io/token/mainnet/${address}/metadata`, { headers })
+        ]);
+        const priceJson = await priceRes.json();
+        const metaJson = await metaRes.json();
+        const usdPrice = priceJson?.prices?.[0]?.usdPrice || 0;
+        const totalSupply = Number(metaJson?.totalSupply ?? 0);
+        return { usdPrice, totalSupply };
+      }
+
+      async function updateLines() {
+        container.innerHTML = '';
+        for (const [symbol, addr] of Object.entries(TOKENS)) {
+          try {
+            const data = await getTokenData(addr);
+            const value = data.totalSupply * data.usdPrice * 0.01;
+            const line = document.createElement('div');
+            line.className = 'line';
+            line.innerHTML = `If you had bought <span class="highlight">1%</span> of <span class="highlight">${symbol}</span> at launch, you'd have <span class="highlight price">${formatUsd(value)}</span> now.`;
+            container.appendChild(line);
+          } catch (e) {
+            // ignore errors
+          }
+        }
+      }
+
+      async function updateIF() {
+        if (!IF_TOKEN_ADDRESS) {
+          finalPriceEl.textContent = '$40';
+          return;
+        }
+        try {
+          const data = await getTokenData(IF_TOKEN_ADDRESS);
+          const value = data.usdPrice * 10000000;
+          finalPriceEl.textContent = formatUsd(value);
+        } catch (e) {
+          finalPriceEl.textContent = '$0';
+        }
+      }
+
+      async function refresh() {
+        await Promise.all([updateLines(), updateIF()]);
+      }
+
+      refresh();
+      setInterval(refresh, 10000);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch real-time prices for WIF, BONK, FART, POPCAT and USELESS
- compute 1% value and inject lines into `#lines-container`
- update IF token price (defaulting to `$40` when no address is set)
- refresh prices every 10 seconds

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68555ba45e3c832bbd981235e6e77d99